### PR TITLE
Add leashing 0.27.0.0 leash

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -68,7 +68,7 @@ if impl (ghc >= 9.12)
 source-repository-package
     type: git
     location: https://github.com/tweag/ouroboros-network
-    tag: 8aa240eef5673d4f397f2037fa95b6fec250f89b
-    --sha256: sha256-rBWeRG83zu67KJGl+eYxB1tZ7GWyjeKaegVnk+YUcCE=
+    tag: 63601d2bd9fa447c1f21efa1a2466e131945cf6e
+    --sha256: sha256-FC/CI67Jk4GNgPPyrWCWl5trCxeon2RSHzhHRZHluak=
     subdir:
       ouroboros-network-protocols

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -36,72 +36,43 @@ localStateQueryServer cfg leashingPointVar getCurrentChainAnchorPoint getView =
   where
     idle :: ServerStIdle blk (Point blk) (Query blk) m ()
     idle = ServerStIdle {
-          recvMsgAcquire = \tgt leashed -> do
+          recvMsgAcquire = \tgt leashId -> do
             traceM $ "idle: handle acquire"
-            handleAcquire tgt leashed
-        , recvMsgDone    = return ()
+            handleAcquire tgt leashId
+        , recvMsgDone    = do
+            traceM "idle: done"
+            return ()
         }
 
     handleAcquire :: Target (Point blk)
                   -> Maybe LeashID
                   -> m (ServerStAcquiring blk (Point blk) (Query blk) m ())
-    handleAcquire mpt leashed = do
-      traceM $ "handleAcquire: start " <> show leashed
+    handleAcquire mpt mLeashId = do
+      traceM $ "handleAcquire: start " <> show mLeashId
       getView mpt >>= \case
-        -- case if we want to leash and there is a leashing point var
-        Right forker | Just leashId <- leashed ->
-            atomically $ putLeashPoint forker mpt leashId
+        Right forker | Just leashId <- mLeashId -> do
+            atomically (acquireLeash mpt leashId) >>= \case
+              Just err -> pure $ SendMsgFailure err idle
+              Nothing  -> pure $ SendMsgAcquired $ acquired (Just leashId) forker
         Right forker -> pure $ SendMsgAcquired $ acquired Nothing forker
         Left PointTooOld{} -> pure $ SendMsgFailure AcquireFailurePointTooOld idle
         Left PointNotOnChain -> pure $ SendMsgFailure AcquireFailurePointNotOnChain idle
 
-    requestedPoint mpt = case mpt of
-        SpecificPoint p -> pure p
-        _ -> getCurrentChainAnchorPoint
-
-    putLeashPoint forker mpt messageLeashId = do
-        traceM $ "SETTING LEASHING POINT VARIABLE"
-        readTVar leashingPointVar >>= \case
-          Nothing -> do
-            -- TODO: What happens if the point is too old?
-            leashState <- (\p -> (messageLeashId,p)) <$> requestedPoint mpt
-            writeTVar leashingPointVar $ Just leashState
-            traceM $ "START LEASHING, LEASHING POINT VARIABLE IS " <> show leashState
-            pure $ SendMsgAcquired $ acquired (Just messageLeashId) forker
-
-          Just current@(currentLeashId, currentLeashPoint)
-            | messageLeashId /= currentLeashId -> do
-              traceM $ "ATTEMPTED TO LEASH WITH WRONG ID: " <> show (currentLeashId, messageLeashId)
-              pure $ SendMsgFailure AcquireFailurePointStateIsBusy idle
-            | otherwise -> do
-                requestedLeashPoint <- requestedPoint mpt
-                let newLeashState = (messageLeashId, requestedLeashPoint)
-                if requestedLeashPoint < currentLeashPoint
-                then do
-                  traceM $ "ATTEMPTED TO LEASH BACKWARDS: "
-                        <> show current
-                        <> " => "
-                        <> show newLeashState
-                  pure $ SendMsgFailure AcquireFailurePointStateIsBusy idle
-                else do
-                  writeTVar leashingPointVar $ Just newLeashState
-                  traceM $ "UPDATED LEASHING, LEASHING POINT VARIABLE IS " <> show newLeashState
-                  pure $ SendMsgAcquired $ acquired (Just messageLeashId) forker
-
     acquired :: Maybe LeashID
              -> ReadOnlyForker' m blk
              -> ServerStAcquired blk (Point blk) (Query blk) m ()
-    acquired leashed forker = ServerStAcquired {
-          recvMsgQuery     = handleQuery leashed forker
+    acquired clientLeashId forker = ServerStAcquired {
+          recvMsgQuery     = do
+            traceM "acquire: query"
+            handleQuery clientLeashId forker
         , recvMsgReAcquire = \mp -> do
-            traceM $ "acquired: re acquire, leash " <> show leashed
+            traceM $ "acquired: re acquire, leash " <> show clientLeashId
             close
-            handleAcquire mp leashed
-        , recvMsgRelease   = do
-            traceM $ "acquired: release, leash " <> show leashed
+            handleAcquire mp clientLeashId
+        , recvMsgRelease   = \msgLeashId -> do
+            traceM $ "acquired: release, leash " <> show msgLeashId
             close
-            -- TODO: Is this right? I think we need to make unleashing explicit
-            atomically $ writeTVar leashingPointVar Nothing
+            releaseLeash msgLeashId
             return idle
         }
       where
@@ -112,6 +83,51 @@ localStateQueryServer cfg leashingPointVar getCurrentChainAnchorPoint getView =
       -> ReadOnlyForker' m blk
       -> Query blk result
       -> m (ServerStQuerying blk (Point blk) (Query blk) m () result)
-    handleQuery leashed forker query = do
+    handleQuery leashId forker query = do
       result <- Query.answerQuery cfg forker query
-      return $ SendMsgResult result (acquired leashed forker)
+      return $ SendMsgResult result (acquired leashId forker)
+
+    -- TODO: This should always compare with getCurrentChainAnchorPoint to
+    -- check if the point is too old.
+    requestedPoint mpt = case mpt of
+        SpecificPoint p -> pure p
+        _ -> getCurrentChainAnchorPoint
+
+    acquireLeash mpt messageLeashId = do
+        traceM $ "SETTING LEASHING POINT VARIABLE"
+        readTVar leashingPointVar >>= \case
+          Nothing -> do
+            -- TODO: What happens if the point is too old?
+            leashPoint <- requestedPoint mpt
+            let newLeashState = (messageLeashId, leashPoint)
+            traceM $ "START LEASHING, LEASHING POINT VARIABLE IS " <> show newLeashState
+            writeTVar leashingPointVar $ Just newLeashState
+            pure Nothing
+
+          Just currentState@(currentLeashId, currentLeashPoint)
+            | messageLeashId /= currentLeashId -> do
+              traceM $ unwords ["ATTEMPTED TO UPDATE LEASH WITH WRONG ID, current:",
+                                show currentLeashId, "provided:", show messageLeashId]
+              pure $ Just AcquireFailurePointStateIsBusy
+
+            | otherwise -> do
+                requestedLeashPoint <- requestedPoint mpt
+                let newState = (messageLeashId, requestedLeashPoint)
+                if requestedLeashPoint < currentLeashPoint
+                then do
+                  traceM $ unwords ["ATTEMPTED TO LEASH BACKWARDS:", show currentState, "=>", show newState]
+                  pure $ Just AcquireFailurePointStateIsBusy
+                else do
+                  traceM $ "UPDATED LEASHING, LEASHING POINT VARIABLE IS " <> show newState
+                  writeTVar leashingPointVar $ Just newState
+                  pure Nothing
+
+    releaseLeash :: Maybe LeashID -> m ()
+    releaseLeash Nothing = pure ()
+    releaseLeash (Just leashId) = atomically $
+      readTVar leashingPointVar >>= \case
+        Just x@(currentId,_)
+          | leashId == currentId -> do
+            traceM $ "LEASH RELEASED: " <> show x
+            writeTVar leashingPointVar Nothing
+        _ -> pure ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -15,7 +15,7 @@ import           Ouroboros.Consensus.Storage.LedgerDB
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.Protocol.LocalStateQuery.Server
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
-                     (AcquireFailure (..), Target (..))
+                     (AcquireFailure (..), Target (..), LeashID)
 
 localStateQueryServer ::
      forall m blk.
@@ -25,7 +25,7 @@ localStateQueryServer ::
      , LedgerSupportsProtocol blk
      )
   => ExtLedgerCfg blk
-  -> ( StrictTVar m (Maybe (Point blk)))
+  -> ( StrictTVar m (Maybe (LeashID, Point blk)))
   -> ( STM m (Point blk) )
   -> (   Target (Point blk)
       -> m (Either GetForkerError (ReadOnlyForker' m blk))
@@ -37,56 +37,78 @@ localStateQueryServer cfg leashingPointVar getCurrentChainAnchorPoint getView =
     idle :: ServerStIdle blk (Point blk) (Query blk) m ()
     idle = ServerStIdle {
           recvMsgAcquire = \tgt leashed -> do
-            traceM $ "idle: handle acquire" 
+            traceM $ "idle: handle acquire"
             handleAcquire tgt leashed
         , recvMsgDone    = return ()
         }
 
     handleAcquire :: Target (Point blk)
-                  -> Bool
+                  -> Maybe LeashID
                   -> m (ServerStAcquiring blk (Point blk) (Query blk) m ())
     handleAcquire mpt leashed = do
-      traceM $ "handleAcquire: start " <> show leashed 
-      getView mpt >>= \case 
+      traceM $ "handleAcquire: start " <> show leashed
+      getView mpt >>= \case
         -- case if we want to leash and there is a leashing point var
-        Right forker
-          | leashed ->
-            atomically $ do
-              traceM $ "SETTING LEASHING POINT VARIABLE" 
-              readTVar leashingPointVar >>= \case
-                Nothing -> do
-                  leashingPoint <- case mpt of
-                    SpecificPoint p -> pure p
-                    _ -> getCurrentChainAnchorPoint
-                  writeTVar leashingPointVar $ Just leashingPoint
-                  traceM $ "LEASHING POINT VARIABLE IS " <> show leashingPoint 
-                  pure $ SendMsgAcquired $ acquired True forker
-                -- return error if already leashed
-                Just _ -> pure $ SendMsgFailure AcquireFailurePointStateIsBusy idle
-        Right forker -> pure $ SendMsgAcquired $ acquired False forker
+        Right forker | Just leashId <- leashed ->
+            atomically $ putLeashPoint forker mpt leashId
+        Right forker -> pure $ SendMsgAcquired $ acquired Nothing forker
         Left PointTooOld{} -> pure $ SendMsgFailure AcquireFailurePointTooOld idle
         Left PointNotOnChain -> pure $ SendMsgFailure AcquireFailurePointNotOnChain idle
 
-    acquired :: Bool
+    requestedPoint mpt = case mpt of
+        SpecificPoint p -> pure p
+        _ -> getCurrentChainAnchorPoint
+
+    putLeashPoint forker mpt messageLeashId = do
+        traceM $ "SETTING LEASHING POINT VARIABLE"
+        readTVar leashingPointVar >>= \case
+          Nothing -> do
+            -- TODO: What happens if the point is too old?
+            leashState <- (\p -> (messageLeashId,p)) <$> requestedPoint mpt
+            writeTVar leashingPointVar $ Just leashState
+            traceM $ "START LEASHING, LEASHING POINT VARIABLE IS " <> show leashState
+            pure $ SendMsgAcquired $ acquired (Just messageLeashId) forker
+
+          Just current@(currentLeashId, currentLeashPoint)
+            | messageLeashId /= currentLeashId -> do
+              traceM $ "ATTEMPTED TO LEASH WITH WRONG ID: " <> show (currentLeashId, messageLeashId)
+              pure $ SendMsgFailure AcquireFailurePointStateIsBusy idle
+            | otherwise -> do
+                requestedLeashPoint <- requestedPoint mpt
+                let newLeashState = (messageLeashId, requestedLeashPoint)
+                if requestedLeashPoint < currentLeashPoint
+                then do
+                  traceM $ "ATTEMPTED TO LEASH BACKWARDS: "
+                        <> show current
+                        <> " => "
+                        <> show newLeashState
+                  pure $ SendMsgFailure AcquireFailurePointStateIsBusy idle
+                else do
+                  writeTVar leashingPointVar $ Just newLeashState
+                  traceM $ "UPDATED LEASHING, LEASHING POINT VARIABLE IS " <> show newLeashState
+                  pure $ SendMsgAcquired $ acquired (Just messageLeashId) forker
+
+    acquired :: Maybe LeashID
              -> ReadOnlyForker' m blk
              -> ServerStAcquired blk (Point blk) (Query blk) m ()
     acquired leashed forker = ServerStAcquired {
           recvMsgQuery     = handleQuery leashed forker
         , recvMsgReAcquire = \mp -> do
-          traceM $ "acquired: re acquire, leash " <> show leashed 
-          close
-          handleAcquire mp leashed
+            traceM $ "acquired: re acquire, leash " <> show leashed
+            close
+            handleAcquire mp leashed
         , recvMsgRelease   = do
-          traceM $ "acquired: release, leash " <> show leashed 
-          close
-          atomically $ writeTVar leashingPointVar Nothing 
-          return idle
+            traceM $ "acquired: release, leash " <> show leashed
+            close
+            -- TODO: Is this right? I think we need to make unleashing explicit
+            atomically $ writeTVar leashingPointVar Nothing
+            return idle
         }
       where
         close = roforkerClose forker
 
     handleQuery ::
-         Bool
+         Maybe LeashID
       -> ReadOnlyForker' m blk
       -> Query blk result
       -> m (ServerStQuerying blk (Point blk) (Query blk) m () result)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -393,7 +393,7 @@ data ChainDB m blk = ChainDB {
       -- in the tables.
     , getStatistics      :: m (Maybe Statistics)
 
-    , getLeashingPointVar   :: !(StrictTVar m (Maybe (Point blk)))
+    , getLeashingPointVar   :: !(StrictTVar m (Maybe (LeashID, Point blk)))
 
        -- | Close the ChainDB
       --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -514,7 +514,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
           <*> VolatileDB.getBlockInfo         cdbVolatileDB
           <*> Query.getCurrentChain           cdb
           <*> Query.getTipPoint               cdb
-          <*> (readTVar cdbLeashingPoint)
+          <*> (fmap snd <$> readTVar cdbLeashingPoint)
 
     -- This is safe: the LedgerDB tip doesn't change in between the previous
     -- atomically block and this call to 'withTipForker'.
@@ -644,6 +644,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
       -> LoE (AnchoredFragment (HeaderWithTime blk))
          -- ^ LoE fragment
       -> Maybe (Point blk)
+      -- ^ Leashing point
       -> m ()
     addToCurrentChain rr succsOf curChainAndLedger loeFrag leashingPoint = do
         -- Extensions of @B@ that do not exceed the LoE
@@ -686,7 +687,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
         -- extension of the current chain.
         case chainDiffs of
           Nothing          -> return ()
-          Just chainDiffs' -> 
+          Just chainDiffs' ->
             chainSelection chainSelEnv rr chainDiffs' >>= \case
               Nothing ->
                 return ()
@@ -741,7 +742,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
                       else candPrefix
               in Diff.diff (VF.validatedFragment curChain) trimmedCand
 
-    trimLeashing :: 
+    trimLeashing ::
       Maybe (Point blk) ->
       ChainAndLedger m blk ->
       ChainDiff (Header blk) ->
@@ -761,7 +762,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
 
             -- if the leashingPoint > anchor
             --
-            -- a. volatile tip < leashingPoint 
+            -- a. volatile tip < leashingPoint
             -- b. anchor < leashingPoint < volatile tip
             --
             -- we want the diff = anchor :| [ b_x | x < leashingPoint]
@@ -786,6 +787,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
       -> ChainDiff (HeaderFields blk)
          -- ^ Header fields for @(x,b]@
       -> Maybe (Point blk)
+      -- ^ Leashing point
       -> m ()
     switchToAFork rr succsOf lookupBlockInfo curChainAndLedger loeFrag diff leashingPoint = do
         -- We use a cache to avoid reading the headers from disk multiple
@@ -828,7 +830,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
             chainSelection chainSelEnv rr chainDiffs' >>= \case
               Nothing                 ->
                 return ()
-              Just validatedChainDiff -> 
+              Just validatedChainDiff ->
                   switchTo
                     validatedChainDiff
                     (varTentativeHeader chainSelEnv)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -122,6 +122,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (MaxSlotNo (..))
 import           Ouroboros.Network.BlockFetch.ConsensusInterface
                      (ChainSelStarvation (..))
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (LeashID)
 
 -- | All the serialisation related constraints needed by the ChainDB.
 class ( ImmutableDbSerialiseConstraints blk
@@ -310,7 +311,7 @@ data ChainDbEnv m blk = CDB
   , cdbChainSelStarvation :: !(StrictTVar m ChainSelStarvation)
     -- ^ Information on the last starvation of ChainSel, whether ongoing or
     -- ended recently.
-  , cdbLeashingPoint :: !(StrictTVar m (Maybe (Point blk)))
+  , cdbLeashingPoint :: !(StrictTVar m (Maybe (LeashID, Point blk)))
   } deriving (Generic)
 
 -- | We include @blk@ in 'showTypeOf' because it helps resolving type families

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -47,7 +47,7 @@ import           Ouroboros.Consensus.Storage.LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots
 import           Ouroboros.Consensus.Storage.LedgerDB.V1.Args
-import           Ouroboros.Consensus.Util.IOLike 
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.Mock.Chain (Chain (..))
 import qualified Ouroboros.Network.Mock.Chain as Chain
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client
@@ -55,7 +55,7 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Examples
                      (localStateQueryClient)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Server
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
-                     (AcquireFailure (..), State (..), Target (..))
+                     (AcquireFailure (..), State (..), Target (..), LeashID)
 import           System.FS.API (SomeHasFS (..))
 import qualified System.FS.Sim.MockFS as MockFS
 import           System.FS.Sim.STM
@@ -103,7 +103,7 @@ prop_localStateQueryServer k bt p (Positive (Small n)) = checkOutcome k chain ac
       ++ (SpecificPoint . blockPoint <$> treeToBlocks bt)
 
 
-    actualOutcome :: [(Target (Point TestBlock), Bool, Either AcquireFailure (Point TestBlock))]
+    actualOutcome :: [(Target (Point TestBlock), Maybe LeashID, Either AcquireFailure (Point TestBlock))]
     actualOutcome = runSimOrThrow $ withRegistry $ \rr ->do
       let client = mkClient points
       server <- mkServer rr k chain
@@ -130,7 +130,7 @@ prop_localStateQueryServer k bt p (Positive (Small n)) = checkOutcome k chain ac
 checkOutcome ::
      SecurityParam
   -> Chain TestBlock
-  -> [(Target (Point TestBlock), Bool, Either AcquireFailure (Point TestBlock))]
+  -> [(Target (Point TestBlock), Maybe LeashID, Either AcquireFailure (Point TestBlock))]
   -> Property
 checkOutcome k chain = conjoin . map (\(tgt, _leashed, er) -> (uncurry checkResult) (tgt, er))
   where
@@ -179,8 +179,8 @@ mkClient ::
        (Point TestBlock)
        (Query TestBlock)
        m
-       [(Target (Point TestBlock), Bool, Either AcquireFailure (Point TestBlock))]
-mkClient points = localStateQueryClient [(pt, False, BlockQuery QueryLedgerTip) | pt <- points]
+       [(Target (Point TestBlock), Maybe LeashID, Either AcquireFailure (Point TestBlock))]
+mkClient points = localStateQueryClient [(pt, Nothing, BlockQuery QueryLedgerTip) | pt <- points]
 
 mkServer ::
      IOLike m


### PR DESCRIPTION
Adds support for specifying a LeashID when using the leashed version of the LocalStateQuery protocol. The idea is that any node which can provide the current LeashID is able to control the lashing, and any other node will be rejected. If no node is currently leashing the node, this will begin leashing. 

(For anyone not familiar with the project, this is part of an experiment for the plutus-script-reexecutor (PSR) project which aims to leash a node's progress until the PSR has completed processing each block. This implementation is just a proof of concept.)

# Description

Please include a meaningful description of the PR and link the relevant issues
this PR might resolve.

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.
