### PR TITLE
Add set of currently active leash clients to LsqLeashingState

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -48,6 +48,8 @@ import Data.Function (on)
 import Data.Functor ((<&>))
 import Data.Hashable (Hashable)
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (isJust, mapMaybe)
 import Data.Proxy
@@ -328,14 +330,14 @@ initNodeKernel
         ps_POLICY_PEER_SHARE_STICKY_TIME
         ps_POLICY_PEER_SHARE_MAX_PEERS
 
-    varLsqLeashingState <- newTVarIO $ mempty 
-    varGenesisLoEFragment <- newTVarIO LoEDisabled 
+    varLsqLeashingState <- newTVarIO $ ChainDB.LsqLeashingState Map.empty Set.empty
+    varGenesisLoEFragment <- newTVarIO LoEDisabled
     varLoEFragment <- newTVarIO LoEDisabled
 
-    atomically $ writeTVar varGetLoEFragment (readTVarIO varLoEFragment) 
+    atomically $ writeTVar varGetLoEFragment (readTVarIO varLoEFragment)
 
     void $ forkLinkedWatcher registry "NodeKernel.LsqLeashing" $
-        lsqLeashingWatcher 
+        lsqLeashingWatcher
           (lsqLeashingTracer tracers)
           crucialLsqClients
           chainDB
@@ -354,7 +356,7 @@ initNodeKernel
             (lgnkaGDDRateLimit lgArgs)
             (readTVar varGsmState)
             (cschcMap varChainSyncHandles)
-            varGenesisLoEFragment 
+            varGenesisLoEFragment
 
     void $
       forkLinkedThread registry "NodeKernel.blockForging" $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE/CaughtUp.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE/CaughtUp.hs
@@ -100,7 +100,7 @@ run = withRegistry \registry -> do
         ChainDB.LoEEnabled $
           AF.Empty AF.AnchorGenesis
 
-  atomically $ writeTVar varGetLoEFragment (readTVarIO varLoE) 
+  atomically $ writeTVar varGetLoEFragment (readTVarIO varLoE)
 
   chainDB <- openChainDB registry (join $ readTVarIO varGetLoEFragment)
   let addBlk = ChainDB.addBlock_ chainDB Punishment.noPunishment
@@ -118,7 +118,7 @@ run = withRegistry \registry -> do
   forkLsqLeashing
     registry
     chainDB
-    (pure mempty)
+    (pure $ ChainDB.LsqLeashingState mempty mempty)
     (readTVar varGenesisLoEFragment)
     varLoE
 
@@ -127,7 +127,7 @@ run = withRegistry \registry -> do
     chainSyncHandles
     chainDB
     (readTVar varGsmState)
-    varGenesisLoEFragment 
+    varGenesisLoEFragment
 
   -- Make sure that the ChainDB background thread, the GSM and the GDD are
   -- running (any positive amount should do).
@@ -344,9 +344,9 @@ forkLsqLeashing ::
 forkLsqLeashing registry chainDB getLsqLeashingState getGenesisLoE varLoE =
   void $
     forkLinkedWatcher registry "LsqLeashing" $
-      lsqLeashingWatcher 
+      lsqLeashingWatcher
         nullTracer
-        mempty 
+        mempty
         chainDB
         getLsqLeashingState
         getGenesisLoE

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -22,6 +22,7 @@ import Data.List (sort)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config (TopLevelConfig (..))
 import Ouroboros.Consensus.Genesis.Governor (gddWatcher)
@@ -42,7 +43,7 @@ import Ouroboros.Consensus.MiniProtocol.ChainSync.Client
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.Node.GsmState as GSM
 import Ouroboros.Consensus.Storage.ChainDB.API
-import qualified Ouroboros.Consensus.Node.LsqLeashing as LsqLeashing 
+import qualified Ouroboros.Consensus.Node.LsqLeashing as LsqLeashing
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Util.Condense (Condense (..))
 import Ouroboros.Consensus.Util.IOLike
@@ -471,13 +472,13 @@ startNode schedulerConfig genesisTest interval = do
         varGenesisLoE
 
     void $ forkLinkedWatcher lrRegistry "LoE leashing updater background" $
-      LsqLeashing.lsqLeashingWatcher 
+      LsqLeashing.lsqLeashingWatcher
         nullTracer
         mempty
         lnChainDb
         (readTVar lrLsqLeashingStateVar)
         (readTVar varGenesisLoE)
-        lrLoEVar 
+        lrLoEVar
 
   void $
     forkLinkedWatcher lrRegistry "CSJ invariants watcher" $
@@ -541,7 +542,7 @@ nodeLifecycle ::
 nodeLifecycle schedulerConfig genesisTest lrTracer lrRegistry lrPeerSim = do
   lrCdb <- emptyNodeDBs
   lrLoEVar <- mkLoEVar schedulerConfig
-  lrLsqLeashingStateVar <- newTVarIO Map.empty 
+  lrLsqLeashingStateVar <- newTVarIO $ ChainDB.LsqLeashingState Map.empty Set.empty
   let
     resources =
       LiveResources

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -4,12 +4,14 @@
 module Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server (localStateQueryServer) where
 
 import Debug.Trace (traceM)
-import Control.Monad (void, when)
+import Control.Monad (when)
+import Data.Foldable (for_, toList)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import Ouroboros.Consensus.Storage.ChainDB.API (LsqLeashingState)
+import Ouroboros.Consensus.Storage.ChainDB.API (LsqLeashingState(..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Query
@@ -44,48 +46,73 @@ localStateQueryServer ::
   ) ->
   LocalStateQueryServer blk (Point blk) (Query blk) m ()
 localStateQueryServer cfg lsqLeashingStateVar getCurrentChain getView =
-  LocalStateQueryServer $ return idle
+  LocalStateQueryServer $ return (idle Nothing)
  where
-  idle :: ServerStIdle blk (Point blk) (Query blk) m ()
-  idle =
+  idle :: Maybe LeashId -> ServerStIdle blk (Point blk) (Query blk) m ()
+  idle clientLeashId  =
     ServerStIdle
-      { recvMsgAcquire = \tgt leashId -> do
-          traceM $ "idle: handle acquire" 
-          handleAcquire tgt leashId
-      , recvMsgDone = \mLeashId -> 
-          void $ traverse releaseLeash mLeashId
+      { recvMsgAcquire = \tgt newLeashId -> do
+          traceM $ "idle: handle acquire"
+          -- TODO: The client can send a new LeashId here, which might be different
+          -- to the already known clientLeashId - this should probably return an error
+          -- if it doesn't match. Alternatively it could remove the existing ID from
+          -- the LsqLeashingState using releaseLeash.
+          handleAcquire tgt newLeashId
+      -- TODO: MsgDone shouldn't need LeashId now, if there was a leashId it was
+      -- passed as an argument.
+      , recvMsgDone = \_notNeeded -> do
+          traceM "MsgDone"
+          deactivateLeashClient clientLeashId
+          -- TODO: Decide if this is right
+          -- void $ traverse releaseLeash clientLeashId
+          return ()
       }
 
   handleAcquire :: Target (Point blk)
                 -> Maybe LeashId
                 -> m (ServerStAcquiring blk (Point blk) (Query blk) m ())
-  handleAcquire mpt mLeashId = do
-    traceM $ "handleAcquire: start " <> show mLeashId 
+  handleAcquire mpt newLeashId = do
+    traceM $ "handleAcquire: start " <> show newLeashId
 
     -- by @nfrisby:
     -- TODO: There's a race condition here; the selection might change between thegetViewcall and this getCurrentChain call.
     -- Might just have to add the "chain that was the current chain at the time of the call" to the range of ChainDB.getReadOnlyForkerAtPoint.
     -- TODO: or maybe a Forker's API already lets you determine what chain fragment it matches? I'm still not super-familiar with the UTxO HD api, which is where Forker comes from
 
-    getView mpt >>= \case 
+    getView mpt >>= \case
       -- case if we want to leash and there is a lsq leashing state var
       Right forker
-        | Just leashId <- mLeashId -> do
-          traceM $ "My leash id " <> show leashId 
+        | Just leashId <- newLeashId -> do
+          traceM $ "My leash id " <> show leashId
           atomically $ do
-            lsqLeashingState <- readTVar lsqLeashingStateVar
-            currentChain <- getCurrentChain 
-            let
-              leashingFragment = case mpt of
-                  ImmutableTip -> AF.Empty $ AF.anchor currentChain
-                  SpecificPoint p -> AF.takeWhileOldest (\(HeaderWithTime h _) -> headerPoint h <= p) currentChain
-                  VolatileTip -> currentChain
-            let newState = Map.insert leashId leashingFragment lsqLeashingState 
-            writeTVar lsqLeashingStateVar newState
-            pure $ SendMsgAcquired $ acquired mLeashId forker
+            activeClients <- lsqActiveClients <$> readTVar lsqLeashingStateVar
+            if Set.member leashId activeClients
+            then do
+              traceM $ "LeashId already in use: " <> show (leashId, activeClients)
+              -- TODO: Need a busy error again - AcquireFailureLeashIdInUse
+              pure $ SendMsgFailure AcquireFailurePointNotOnChain (idle Nothing)
+            else do
+              handleAcquireLeash mpt leashId
+              pure $ SendMsgAcquired $ acquired (Just leashId) forker
       Right forker -> pure $ SendMsgAcquired $ acquired Nothing forker
-      Left PointTooOld{} -> pure $ SendMsgFailure AcquireFailurePointTooOld idle
-      Left PointNotOnChain -> pure $ SendMsgFailure AcquireFailurePointNotOnChain idle
+      Left PointTooOld{} -> pure $ SendMsgFailure AcquireFailurePointTooOld (idle newLeashId)
+      Left PointNotOnChain -> pure $ SendMsgFailure AcquireFailurePointNotOnChain (idle newLeashId)
+
+  handleAcquireLeash :: Target (Point blk) -> LeashId -> STM m ()
+  handleAcquireLeash mpt leashId = do
+    lsqLeashingState <- readTVar lsqLeashingStateVar
+    currentChain <- getCurrentChain
+    let
+      leashingFragment = case mpt of
+          ImmutableTip -> AF.Empty $ AF.anchor currentChain
+          SpecificPoint p -> AF.takeWhileOldest (\(HeaderWithTime h _) -> headerPoint h <= p) currentChain
+          VolatileTip -> currentChain
+
+    writeTVar lsqLeashingStateVar LsqLeashingState {
+      lsqLeashes = Map.insert leashId leashingFragment (lsqLeashes lsqLeashingState),
+      lsqActiveClients = Set.insert leashId (lsqActiveClients lsqLeashingState)
+    }
+
 
   acquired :: Maybe LeashId
            -> ReadOnlyForker' m blk
@@ -99,10 +126,10 @@ localStateQueryServer cfg lsqLeashingStateVar getCurrentChain getView =
           close
           handleAcquire mp clientLeashId
       , recvMsgRelease   = \unleash -> do
-          traceM $ "acquired: release, leash " <> show clientLeashId 
+          traceM $ "acquired: release, leash " <> show clientLeashId
           close
-          when unleash $ void $ traverse releaseLeash clientLeashId 
-          return idle
+          when unleash $ for_ clientLeashId releaseLeash
+          return (idle clientLeashId)
       }
     where
       close = roforkerClose forker
@@ -117,7 +144,19 @@ localStateQueryServer cfg lsqLeashingStateVar getCurrentChain getView =
     return $ SendMsgResult result (acquired leashId forker)
 
   releaseLeash :: LeashId -> m ()
-  releaseLeash leashId = atomically $ do
-    lsqLeashingState <- readTVar lsqLeashingStateVar
-    let newState = Map.delete leashId lsqLeashingState 
-    writeTVar lsqLeashingStateVar newState
+  releaseLeash leashId = do
+    active <- atomically $
+      stateTVar lsqLeashingStateVar $ \l ->
+        let l' = l{
+          lsqLeashes = Map.delete leashId (lsqLeashes l) ,
+          lsqActiveClients = Set.delete leashId (lsqActiveClients l)
+          }
+        in (toList $ lsqActiveClients l', l')
+    traceM $ "currently live clients: " <> show active
+
+  deactivateLeashClient :: Maybe LeashId -> m ()
+  deactivateLeashClient Nothing = pure ()
+  deactivateLeashClient (Just leashId) = atomically $ do
+    traceM $ "Releasing active leash: " <> show leashId
+    modifyTVar lsqLeashingStateVar $ \l ->
+      l { lsqActiveClients = Set.delete leashId (lsqActiveClients l) }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/LsqLeashing.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/LsqLeashing.hs
@@ -10,7 +10,7 @@
 
 module Ouroboros.Consensus.Node.LsqLeashing (
     TraceLsqLeashingEvent(..)
-  , lsqLeashingWatcher 
+  , lsqLeashingWatcher
   ) where
 
 import           Control.Monad (void)
@@ -21,7 +21,7 @@ import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
-import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB, LsqLeashingState)
+import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB, LsqLeashingState(..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Util.AnchoredFragment (sharedCandidatePrefix)
 import           Ouroboros.Consensus.Util.IOLike
@@ -32,7 +32,7 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type (LeashId)
 
 -- | We want to know if either
 -- 1. Any lsqLeashing fragment was updated. The map contains information about active
--- `LocalStateQuery` servers that enabled leashing providing their fragment. 
+-- `LocalStateQuery` servers that enabled leashing providing their fragment.
 -- 2. The genesis LoE fragment was updated.
 type LsqLeashingFingerprint blk =
   (Map.Map LeashId (ChainHash (HeaderWithTime blk)), ChainDB.LoE (ChainHash (HeaderWithTime blk)))
@@ -54,16 +54,16 @@ lsqLeashingWatcher ::
   => Tracer m (TraceLsqLeashingEvent blk)
   -> Set LeashId
   -> ChainDB m blk
-  -> STM m (LsqLeashingState blk) 
+  -> STM m (LsqLeashingState blk)
   -> STM m (ChainDB.LoE (AnchoredFragment (HeaderWithTime blk)))
    -- ^ The Genesis LoE fragment.
   -> StrictTVar m (ChainDB.LoE (AnchoredFragment (HeaderWithTime blk)))
-   -- ^ The resulting leashing LoE fragment. 
+   -- ^ The resulting leashing LoE fragment.
   -> Watcher m (LsqLeashingWatcherState blk) (LsqLeashingFingerprint blk)
 lsqLeashingWatcher tracer crucialLsqClients chainDb getLsqLeashingState getGenesisLoEFrag varLoEFrag =
     Watcher {
         wInitial = Nothing
-      , wReader 
+      , wReader
       , wFingerprint
       , wNotify
       }
@@ -78,12 +78,12 @@ lsqLeashingWatcher tracer crucialLsqClients chainDb getLsqLeashingState getGenes
     wFingerprint ::
          LsqLeashingWatcherState blk
       -> LsqLeashingFingerprint blk
-    wFingerprint LsqLeashingWatcherState{..} = (Map.map AF.headHash lsqLeashingState, AF.headHash <$> genesisLoE)
+    wFingerprint LsqLeashingWatcherState{..} = (Map.map AF.headHash (lsqLeashes lsqLeashingState), AF.headHash <$> genesisLoE)
 
     wNotify :: (LsqLeashingWatcherState blk) -> m ()
     wNotify LsqLeashingWatcherState{..} = do
         let
-          lsqLeashingCandidates = Map.toList lsqLeashingState
+          lsqLeashingCandidates = Map.toList (lsqLeashes lsqLeashingState)
           prefix = case genesisLoE of
               ChainDB.LoEEnabled frag -> frag
               ChainDB.LoEDisabled -> curChain
@@ -93,12 +93,12 @@ lsqLeashingWatcher tracer crucialLsqClients chainDb getLsqLeashingState getGenes
             if Set.null crucialLsqClients
             then
               -- if there are no crucial lsq clients and leashing state is empty, return genesis LoE
-              if Map.null lsqLeashingState
+              if Map.null (lsqLeashes lsqLeashingState)
               then genesisLoE
               else ChainDB.LoEEnabled lsqLeashingFrag
             else
               -- there are crucial lsq clients,
-              -- if they are present, we leash in usual way 
+              -- if they are present, we leash in usual way
               -- otherwise return the anchor of the current chain to leash the node at immutable tip
               if crucialLsqClientsArePresent then ChainDB.LoEEnabled lsqLeashingFrag
               else ChainDB.LoEEnabled $ AF.Empty $ AF.castAnchor $ AF.anchor curChain
@@ -116,7 +116,7 @@ lsqLeashingWatcher tracer crucialLsqClients chainDb getLsqLeashingState getGenes
               void $ ChainDB.triggerChainSelectionAsync chainDb
             | otherwise ->
               -- no changes
-              pure () 
+              pure ()
           (_, _) ->
             -- LoE either was enabled or disabled
             void $ ChainDB.triggerChainSelectionAsync chainDb

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -921,5 +921,17 @@ data LsqLeashingState blk = LsqLeashingState
   -- ^ All currently active client IDs
   } deriving (Generic)
 
-deriving instance (Ord (HeaderHash blk), Typeable (HeaderHash blk), Show (HeaderHash blk), NoThunks (HeaderHash blk), Show (Header blk)) => Show (LsqLeashingState blk)
-deriving instance (Ord (HeaderHash blk), Typeable (HeaderHash blk), Show (HeaderHash blk), NoThunks (HeaderHash blk), NoThunks (Header blk)) => NoThunks (LsqLeashingState blk)
+deriving instance
+  (Ord (HeaderHash blk)
+  , Typeable (HeaderHash blk)
+  , Show (HeaderHash blk)
+  , NoThunks (HeaderHash blk)
+  , Show (Header blk)
+  ) => Show (LsqLeashingState blk)
+deriving instance
+  (Ord (HeaderHash blk)
+  , Typeable (HeaderHash blk)
+  , Show (HeaderHash blk)
+  , NoThunks (HeaderHash blk)
+  , NoThunks (Header blk)
+  ) => NoThunks (LsqLeashingState blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -70,13 +70,14 @@ module Ouroboros.Consensus.Storage.ChainDB.API
     -- * Genesis
   , GetLoEFragment
   , LoE (..)
-  , LsqLeashingState
+  , LsqLeashingState(..)
   ) where
 
 import Control.Monad (void)
 import Control.ResourceRegistry
 import Data.Typeable (Typeable)
 import Data.Map.Strict (Map)
+import Data.Set (Set)
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HeaderStateHistory
@@ -913,4 +914,12 @@ data LoE a
 -- chain, just like candidate fragments.
 type GetLoEFragment m blk = m (LoE (AnchoredFragment (HeaderWithTime blk)))
 
-type LsqLeashingState blk = Map LeashId (AnchoredFragment (HeaderWithTime blk))
+data LsqLeashingState blk = LsqLeashingState
+  { lsqLeashes :: Map LeashId (AnchoredFragment (HeaderWithTime blk))
+  -- ^ All known leashes
+  , lsqActiveClients :: Set LeashId
+  -- ^ All currently active client IDs
+  } deriving (Generic)
+
+deriving instance (Ord (HeaderHash blk), Typeable (HeaderHash blk), Show (HeaderHash blk), NoThunks (HeaderHash blk), Show (Header blk)) => Show (LsqLeashingState blk)
+deriving instance (Ord (HeaderHash blk), Typeable (HeaderHash blk), Show (HeaderHash blk), NoThunks (HeaderHash blk), NoThunks (Header blk)) => NoThunks (LsqLeashingState blk)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -25,6 +25,7 @@ import Control.Monad.IOSim (runSimOrThrow)
 import Control.ResourceRegistry
 import Control.Tracer
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Maybe (fromMaybe)
 import Network.TypedProtocol.Stateful.Proofs (connect)
 import Ouroboros.Consensus.Block
@@ -39,6 +40,7 @@ import Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import Ouroboros.Consensus.NodeId
 import Ouroboros.Consensus.Protocol.BFT
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Storage.ImmutableDB.Stream hiding
   ( streamAPI
   )
@@ -208,7 +210,7 @@ mkServer ::
   m (LocalStateQueryServer TestBlock (Point TestBlock) (Query TestBlock) m ())
 mkServer rr k chain = do
   lgrDB <- initLedgerDB k chain
-  leashingStateVar <- newTVarIO Map.empty 
+  leashingStateVar <- newTVarIO $ ChainDB.LsqLeashingState Map.empty Set.empty
   return $
     localStateQueryServer
       cfg leashingStateVar (pure $ attachSlotTimeToFragment (testCfg k) $ Chain.toAnchoredFragment $ getHeader <$> chain)


### PR DESCRIPTION
Closes https://github.com/tweag/plutus-script-reexecutor/issues/161

Adds a set of currently known leashing client IDs - `LeashId`'s which currently have active connections to clients (and hence an active thread which can update that ID's leash). This should be a subset of all the IDs in the keys of the leash fragments map.

Also note that:

- It is possible that a client sends a new `LeashId` when in the `Idle` state, which does not match the previous `LeashId` from that connection. Currently I'm not checking for or handling that case because I'm not sure what the appropriate action is:

   1. Return a new error to the client
   1. Release the leash for the previous `LeashId` (and remove it from the active set) - see `releaseLeash`.

- I haven't made any changes to the protocol constructors, so the error case when a `LeashId` is reused currently sends `AcquireFailurePointNotOnChain`. This should probably be a new error constructor. `MsgDone` also no longer needs the `Maybe LeashId`, if there is a known ID it will be passed into the `idle` function.